### PR TITLE
handle 0 coverage regions in bam assertions

### DIFF
--- a/genomicassertions/readassertions.py
+++ b/genomicassertions/readassertions.py
@@ -2,25 +2,32 @@ import pysam
 
 
 class ReadAssertions:
-    def __init__(self):
-	pass
 
     def assertBamHasCoverageAt(self, bam, coverage, chrom, pos):
-	samfile = pysam.AlignmentFile(bam, "rb")
-	iter = samfile.pileup('3', pos-1, pos, truncate=True)
-	pile = iter.next()
-	if pile.nsegments != coverage:
-	    raise AssertionError("Coverage at {}:{} was not {} in {} (got {})".format(chrom, pos, coverage, bam, pile.nsegments))
+        samfile = pysam.AlignmentFile(bam, "rb")
+        iter = samfile.pileup('3', pos - 1, pos, truncate=True)
+        try:
+            pile = iter.next()
+            if pile.nsegments != coverage:
+                raise AssertionError(
+                    "Coverage at {}:{} was not {} in {} (got {})".format(
+                        chrom, pos, coverage, bam, pile.nsegments))
+        except StopIteration:
+            if coverage != 0:
+                raise AssertionError(
+                    "Coverage at {}:{} was zero in {}".format(
+                        chrom, pos, bam))
+
 
     def assertBamHasHeaderElement(self, bam, header_element):
-	samfile = pysam.AlignmentFile(bam, "rb")
-	if header_element not in samfile.header:
-	    raise AssertionError("Header element {} not in header of {}".format(header_element, bam))
+        samfile = pysam.AlignmentFile(bam, "rb")
+        if header_element not in samfile.header:
+            raise AssertionError("Header element {} not in header of {}".format(header_element, bam))
 
     def assertBamHeaderElementEquals(self, bam, header_element_name, header_element_value):
-	samfile = pysam.AlignmentFile(bam, "rb")
-	self.assertBamHasHeaderElement(bam, header_element_name)
+        samfile = pysam.AlignmentFile(bam, "rb")
+        self.assertBamHasHeaderElement(bam, header_element_name)
 
-	if samfile.header[header_element_name] != header_element_value:
-	    raise AssertionError("Header element for key {} is incorrect. Check {}, got {}.".format(
-		header_element_name, header_element_value, samfile.header[header_element_name]))
+        if samfile.header[header_element_name] != header_element_value:
+            raise AssertionError("Header element for key {} is incorrect. Check {}, got {}.".format(
+                header_element_name, header_element_value, samfile.header[header_element_name]))

--- a/genomicassertions/variantassertions.py
+++ b/genomicassertions/variantassertions.py
@@ -2,8 +2,6 @@ from vcf import Reader
 
 
 class VariantAssertions:
-    def __init__(self):
-        pass
 
     def assertVcfHasVariantAt(self, vcf, chrom, pos):
         v = Reader(filename=vcf)
@@ -45,12 +43,12 @@ class VariantAssertions:
 
     def assertVcfHasVariantWithCall(self, vcf, chrom, pos, sample, call):
         """
-	Assert that a call is made for a given sample in a given position. `call` is a dict corresponding to elements
-	in the vcf sample field. Example:
+        Assert that a call is made for a given sample in a given position. `call` is a dict corresponding to elements
+        in the vcf sample field. Example:
 
-	self.assertVcfHasVariantWithCall(my_vcf, 1, 3184885, 'B',
-					 call={'GT': '1/2', 'DP': 10})
-	"""
+        self.assertVcfHasVariantWithCall(my_vcf, 1, 3184885, 'B',
+                                         call={'GT': '1/2', 'DP': 10})
+        """
         self.assertVcfHasSample(vcf, sample)
 
         v = Reader(filename=vcf)

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -6,27 +6,34 @@ class TestReads(unittest.TestCase, ReadAssertions):
     bam = "tests/3_178936091.bam"
 
     def test_has_coverage_as_pos(self):
-	self.assertBamHasCoverageAt(self.bam, 324, 3, 178936091)
+        self.assertBamHasCoverageAt(self.bam, 324, 3, 178936091)
+
+    def test_has_0_coverage_at_pos(self):
+        self.assertBamHasCoverageAt(self.bam, 0, 3, 1337)
+
+    def test_nonzero_coverage_at_pos(self):
+        with self.assertRaises(AssertionError):
+            self.assertBamHasCoverageAt(self.bam, 42, 3, 1337)
 
     def test_raises_if_incorrect_coverage(self):
-	with self.assertRaises(AssertionError):
-	    self.assertBamHasCoverageAt(self.bam, 323, 3, 178936091)
+        with self.assertRaises(AssertionError):
+            self.assertBamHasCoverageAt(self.bam, 323, 3, 178936091)
 
     def test_bam_has_header_element(self):
-	self.assertBamHasHeaderElement(self.bam, "HD")
+        self.assertBamHasHeaderElement(self.bam, "HD")
 
     def test_raises_if_header_element_not_in_bam(self):
-	with self.assertRaises(AssertionError):
-	    self.assertBamHasHeaderElement(self.bam, "FOO")
+        with self.assertRaises(AssertionError):
+            self.assertBamHasHeaderElement(self.bam, "FOO")
 
     def test_header_element_equals(self):
-	self.assertBamHeaderElementEquals(self.bam, 'HD', {'SO': 'coordinate', 'VN': '1.3'})
+        self.assertBamHeaderElementEquals(self.bam, 'HD', {'SO': 'coordinate', 'VN': '1.3'})
 
     def assert_raises_if_test_header_element_not_equals(self):
-	# one wrong key in element
-	with self.assertRaises(AssertionError):
-	    self.assertBamHeaderElementEquals(self.bam, 'HD', {'SO': 'coordinate', 'VN': '1.4'})
+        # one wrong key in element
+        with self.assertRaises(AssertionError):
+            self.assertBamHeaderElementEquals(self.bam, 'HD', {'SO': 'coordinate', 'VN': '1.4'})
 
-	# no element with name
-	with self.assertRaises(AssertionError):
-	    self.assertBamHeaderElementEquals(self.bam, 'FOO', {'SO': 'coordinate', 'VN': '1.4'})
+        # no element with name
+        with self.assertRaises(AssertionError):
+            self.assertBamHeaderElementEquals(self.bam, 'FOO', {'SO': 'coordinate', 'VN': '1.4'})


### PR DESCRIPTION
* remove unused `__init__()`
* correctly handle 0 coverage
* whitespace fixes